### PR TITLE
Max file size

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,5 +53,6 @@ AWS_SECRET_ACCESS_KEY        Required. The AWS secret
 S3_DOCUMENT_ROOT_DIRECTORY   Optional. Document root for all uploads (prefix)
 S3_APPEND_DATETIME_ON_UPLOAD Optional [True]. Appent the current datetime sring to the uploaded file name
 S3_PREFIX_QUERY_PARAM_NAME   Optional [__prefix]. A query param key name which provides additional prefix for the object key on S3
-S3_MIN_PART_SIZE             Optional [5MB]. The part size to upload to S3
+S3_MIN_PART_SIZE             Optional [5MB]. The part size in bytes to upload to S3
+MAX_UPLOAD_SIZE              Optional [None]. The maximum file size in bytes for an individual file.
 ============================ =====================================================================================================

--- a/s3chunkuploader/file_handler.py
+++ b/s3chunkuploader/file_handler.py
@@ -18,6 +18,7 @@ S3_DOCUMENT_ROOT_DIRECTORY = getattr(settings, 'S3_DOCUMENT_ROOT_DIRECTORY', '')
 S3_APPEND_DATETIME_ON_UPLOAD = getattr(settings, 'S3_APPEND_DATETIME_ON_UPLOAD', True)
 S3_PREFIX_QUERY_PARAM_NAME = getattr(settings, 'S3_PREFIX_QUERY_PARAM_NAME', '__prefix')
 S3_MIN_PART_SIZE = getattr(settings, 'S3_MIN_PART_SIZE', 5 * 1024 * 1024)
+MAX_UPLOAD_SIZE = getattr(settings, 'MAX_UPLOAD_SIZE', None)
 
 
 class S3Wrapper(object):
@@ -115,6 +116,11 @@ class ThreadedS3ChunkUploader(ThreadPoolExecutor):
             content_length = len(body)
             self.queue.append(body)
             self.current_queue_size += content_length
+
+            # If the current queue size is larger than the max upload size, abort
+            if self.current_queue_size > int(MAX_UPLOAD_SIZE):
+                raise Exception('File too large')
+
         if not body or self.current_queue_size > S3_MIN_PART_SIZE:
             self.part_number += 1
             _body = self.drain_queue()
@@ -179,7 +185,9 @@ class S3FileUploadHandler(FileUploadHandler):
             self.client,
             self.bucket_name,
             key=self.s3_key,
-            upload_id=self.upload_id)
+            upload_id=self.upload_id
+        )
+
         # prepare a storages object as a file placeholder
         self.storage = S3Boto3Storage()
         self.file = S3Boto3StorageFile(self.s3_key, 'w', self.storage)

--- a/s3chunkuploader/file_handler.py
+++ b/s3chunkuploader/file_handler.py
@@ -118,8 +118,9 @@ class ThreadedS3ChunkUploader(ThreadPoolExecutor):
             self.current_queue_size += content_length
 
             # If the current queue size is larger than the max upload size, abort
-            if self.current_queue_size > int(MAX_UPLOAD_SIZE):
-                raise Exception('File too large')
+            if MAX_UPLOAD_SIZE:
+                if self.current_queue_size > int(MAX_UPLOAD_SIZE):
+                    raise Exception('File too large')
 
         if not body or self.current_queue_size > S3_MIN_PART_SIZE:
             self.part_number += 1


### PR DESCRIPTION
Adding max file sizes

It works by adding up the queue size, if its larger than the max size it aborts and throws an UploadError